### PR TITLE
 #158655350 User can only review and rate a product if purchase has been made

### DIFF
--- a/imports/plugins/custom/productReview/client/components/productReviews.js
+++ b/imports/plugins/custom/productReview/client/components/productReviews.js
@@ -6,6 +6,7 @@ import { Meteor } from "meteor/meteor";
 import "../stylesheet/style.css";
 import { registerComponent, composeWithTracker  } from "@reactioncommerce/reaction-components";
 import { Reaction } from "/client/api";
+import { ReactionProduct } from "/lib/api";
 import { Reviews } from "../../lib/collections";
 
 class ProductReview extends Component {
@@ -18,6 +19,13 @@ class ProductReview extends Component {
 
     componentDidMount() {
       this.avarageRating();
+      const productId =  ReactionProduct.selectedProductId();
+      Meteor.call("reviews/isPurchased", productId, (err, result) => {
+        this.setState({
+          ...this.state,
+          isPurchased: result
+        });
+      });
     }
 
     avarageRating = () => {
@@ -51,6 +59,7 @@ class ProductReview extends Component {
        const rating  = parseInt(this.state.rating, 10);
        const userEmail = this.state.user.emails[0].address;
        const productName = Reaction.Router.getParam("handle");
+
        Meteor.call("review/create", rating, review, userEmail, productName);
        Meteor.call("reviews/average", productName);
        this.setState({ rating: 0, review: ""  });
@@ -92,6 +101,12 @@ class ProductReview extends Component {
      const signin = (
        <div>
          <h3>Sign in or Register to Leave a Rating and a Review </h3>
+         <br/>
+       </div>
+     );
+     const noPurchase = (
+       <div>
+         <h3>Please make a purchase before you can review and rate this product</h3>
          <br/>
        </div>
      );
@@ -152,6 +167,8 @@ class ProductReview extends Component {
          return signin;
        } else if (admin === "owner") {
          return adminMessage;
+       } else if (!this.state.isPurchased) {
+         return noPurchase;
        }
        return addReview;
      };

--- a/imports/plugins/custom/productReview/server/methods/productReviews.js
+++ b/imports/plugins/custom/productReview/server/methods/productReviews.js
@@ -1,6 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import { Reviews } from "../../lib/collections";
+import { Orders } from "lib/collections";
 
 Meteor.methods({
   "review/create"(rating, review, userEmail, productName) {
@@ -37,5 +38,17 @@ Meteor.methods({
       result = [0, 0];
     }
     return result[0].averageRate;
+  },
+  "reviews/isPurchased"(productId) {
+    check(productId, String);
+
+    const order = Orders.findOne({
+      "userId": Meteor.userId(),
+      "items.productId": productId
+    });
+    if (order === undefined) {
+      return false;
+    }
+    return true;
   }
 });


### PR DESCRIPTION
### What does this PR do?
Fixes bug that enabled users who haven't purchased a product to review and rate that product.

### Description of tasks to be completed
N/A

### How should this be manually tested ?
Clone the app and install all its dependencies. cd into the app and run it using the _reaction_ command. On a browser, open _localhost:3000_ and register. If no product is purchased, you won't get an option to add a review or rate the product.

### Any background context you want to provide ?
N/A



### Any relevant pivotal tracker stories ?
#158655350

### Questions
N/A

